### PR TITLE
Use forward class declaration to simplify data hiding

### DIFF
--- a/SampleCppDll/SampleCppDll.cpp
+++ b/SampleCppDll/SampleCppDll.cpp
@@ -1,6 +1,23 @@
 #include "SampleCppDll.h"
+#include <string>
+#include <memory>
+#include <string.h>
 
 namespace SampleCppDll {
+
+	class CustomString {
+	private:
+		class impl;
+		std::unique_ptr<impl> pimpl;
+
+	public:
+		CustomString();
+		CustomString(const std::string&);
+		void GetString(char* buf, size_t length);
+		size_t GetLength();
+		void Append(const std::string&);
+		void SetCallback(TEXT_CALLBACK callback);
+	};
 
 	/**
 	 * pimpl implementation to hide logic from the header files

--- a/SampleCppDll/SampleCppDll.cpp
+++ b/SampleCppDll/SampleCppDll.cpp
@@ -1,14 +1,13 @@
 #include "SampleCppDll.h"
 #include <string>
-#include <memory>
 #include <string.h>
 
 namespace SampleCppDll {
 
 	class CustomString {
 	private:
-		class impl;
-		std::unique_ptr<impl> pimpl;
+		std::string mText;
+		TEXT_CALLBACK mCallback;
 
 	public:
 		CustomString();
@@ -17,20 +16,6 @@ namespace SampleCppDll {
 		size_t GetLength();
 		void Append(const std::string&);
 		void SetCallback(TEXT_CALLBACK callback);
-	};
-
-	/**
-	 * pimpl implementation to hide logic from the header files
-	 */
-	class CustomString::impl {
-	private:
-	public:
-		std::string mText;
-		TEXT_CALLBACK mCallback;
-
-		void init(std::string inputText) {
-			mText = std::string(inputText);
-		}
 	};
 
 	/**
@@ -44,34 +29,33 @@ namespace SampleCppDll {
 	 * constructor takes a given string parameter
 	 */
 	CustomString::CustomString(const std::string& inputText) {
-		pimpl = std::make_unique<impl>();
-		pimpl->init(inputText);
+		mText = inputText;
 	}
 
 	/**
 	 * retreive the string and put in into a given buffer
 	 */
 	void CustomString::GetString(char* buf, size_t length) {
-		strncpy_s(buf, length, pimpl->mText.c_str(), pimpl->mText.size());
+		strncpy_s(buf, length, mText.c_str(), mText.size());
 	}
 
 	/**
 	 * retreive the length of the string
 	 */
 	size_t CustomString::GetLength() {
-		if (nullptr != pimpl->mCallback) {
-			pimpl->mCallback(false, pimpl->mText.size());
+		if (nullptr != mCallback) {
+			mCallback(false, mText.size());
 		}
-		return pimpl->mText.size();
+		return mText.size();
 	}
 
 	/**
 	 * append to the string
 	 */
 	void CustomString::Append(const std::string& str) {
-		pimpl->mText.append(str);
-		if (nullptr != pimpl->mCallback) {
-			pimpl->mCallback(str.size() > 0, pimpl->mText.size());
+		mText.append(str);
+		if (nullptr != mCallback) {
+			mCallback(str.size() > 0, mText.size());
 		}
 	}
 
@@ -80,7 +64,7 @@ namespace SampleCppDll {
 	 * is for demostrating how to use callback from unity
 	 */
 	void CustomString::SetCallback(TEXT_CALLBACK callback) {
-		pimpl->mCallback = callback;
+		mCallback = callback;
 	}
 
 	/**

--- a/SampleCppDll/SampleCppDll.h
+++ b/SampleCppDll/SampleCppDll.h
@@ -6,8 +6,7 @@
 #define DLL_API __declspec(dllimport) 
 #endif
 
-#include <string>
-#include <memory>
+#include <stddef.h> // size_t
 
 extern "C" {
 
@@ -19,21 +18,9 @@ extern "C" {
 		typedef void(*TEXT_CALLBACK)(bool hasTextChanged, int newLength);
 		
 		/**
-		 * Library class definition
+		 * Library class declaration
 		 */
-		class CustomString {
-		private:
-			class impl;
-			std::unique_ptr<impl> pimpl;
-
-		public:
-			CustomString();
-			CustomString(const std::string&);
-			void GetString(char* buf, size_t length);
-			size_t GetLength();
-			void Append(const std::string&);
-			void SetCallback(TEXT_CALLBACK callback);
-		};
+		class CustomString;
 
 		/**
 		 * Exported functions


### PR DESCRIPTION
Thus the interface header file is clean from any implementation details (as the inclusion of <memory> and <string>).